### PR TITLE
Add CI pipeline to build container and push to registry.

### DIFF
--- a/.github/workflows/deploy-eoapi.yaml
+++ b/.github/workflows/deploy-eoapi.yaml
@@ -1,0 +1,46 @@
+name: build eoapi custom runtime
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - runtimes/eoapi/**
+      - .github/workflows/deploy-eoapi.yaml
+
+jobs:
+  build:
+    name: build eoapi stac component
+    runs-on: "ubuntu-24.04"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to container registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: harbor.develop.eoepca.org
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: harbor.develop.eoepca.org/eoapi/stac
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./runtimes/eoapi
+          file: ./dockerfiles/Dockerfile.stac
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dockerfiles/Dockerfile.stac
+++ b/dockerfiles/Dockerfile.stac
@@ -4,7 +4,7 @@ FROM ghcr.io/vincentsarago/uvicorn-gunicorn:${PYTHON_VERSION}
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 
-COPY runtimes/eoapi/stac /tmp/stac
+COPY ./stac /tmp/stac
 RUN python -m pip install /tmp/stac
 RUN rm -rf /tmp/stac
 


### PR DESCRIPTION
This builds the container for the provided custom runtime of the stac component of eoAPI and pushes it to the project's container registry.

Part of #109 