### PR TITLE
Remove auth from runtime.

### DIFF
--- a/runtimes/eoapi/stac/pyproject.toml
+++ b/runtimes/eoapi/stac/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "starlette-cramjam>=0.3,<0.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",
     "psycopg_pool",
-    "eoapi.auth-utils>=0.2.0",
     "uvicorn>=0.32.1",
 ]
 


### PR DESCRIPTION
Let's build that back, as we are either going with the API gateway or a dedicated proxy to handle authentication: https://github.com/EOEPCA/resource-discovery/issues/101