### PR TITLE
docs: add access control page referencing shared STAC API auth

### DIFF
--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -1,6 +1,6 @@
-# Access Control
+# STAC API Access Control
 
-The Data Access building block shares its eoAPI deployment with the [Resource Discovery building block](https://eoepca.readthedocs.io/projects/resource-discovery/). The STAC API of that deployment is protected by [STAC Auth Proxy](https://github.com/developmentseed/stac-auth-proxy), which validates OIDC tokens issued by the IAM building block and enforces collection-level access policies by injecting CQL2 filters into every request.
+The Data Access building block shares its eoAPI deployment with the [Resource Discovery building block](https://eoepca.readthedocs.io/projects/resource-discovery/). The STAC API of that deployment is protected by [STAC Auth Proxy](https://github.com/developmentseed/stac-auth-proxy), which validates OIDC tokens issued by the IAM building block and enforces collection-level access policies by injecting CQL2 filters into every request. These policies apply to the STAC API only — the raster, vector, and multidimensional APIs are not covered by them.
 
 In brief:
 
@@ -8,6 +8,6 @@ In brief:
 - Collections named `<username>.<collection>` are readable and writable by that user.
 - Collections named `<group>.<collection>` are readable and writable by that group's members; a `-ro` group variant grants read-only access.
 
-Since read responses depend on the caller's identity, clients should send their `Authorization: Bearer <token>` header on all STAC API requests, not only on writes. [STAC Manager](https://github.com/developmentseed/stac-manager), the basis of the data administration interface, does this as of `v1.0.0`.
+Since read responses depend on the caller's identity, clients should send their `Authorization: Bearer <token>` header on all STAC API requests, not only on writes. [STAC Manager](https://github.com/developmentseed/stac-manager), the basis of the data administration interface, does this automatically.
 
 The policy model, enforcement details, and configuration are documented in the Resource Discovery building block: see [Data Catalogue — Access Control](https://eoepca.readthedocs.io/projects/resource-discovery/en/latest/design/data-catalogue/auth/). The policy implementation lives in the [`eoepca-plus` deployment repository](https://github.com/EOEPCA/eoepca-plus/tree/deploy-develop/argocd/eoepca/data-access/parts/stac-auth-proxy).

--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -1,0 +1,13 @@
+# Access Control
+
+The Data Access building block shares its eoAPI deployment with the [Resource Discovery building block](https://eoepca.readthedocs.io/projects/resource-discovery/). The STAC API of that deployment is protected by [STAC Auth Proxy](https://github.com/developmentseed/stac-auth-proxy), which validates OIDC tokens issued by the IAM building block and enforces collection-level access policies by injecting CQL2 filters into every request.
+
+In brief:
+
+- Collections without a `.` in their ID (e.g. `sentinel-2-l2a`) are **public**: anyone can read them, and only the `stac_editor` service role can write them.
+- Collections named `<username>.<collection>` are readable and writable by that user.
+- Collections named `<group>.<collection>` are readable and writable by that group's members; a `-ro` group variant grants read-only access.
+
+Since read responses depend on the caller's identity, clients should send their `Authorization: Bearer <token>` header on all STAC API requests, not only on writes. [STAC Manager](https://github.com/developmentseed/stac-manager), the basis of the data administration interface, does this as of `v1.0.0`.
+
+The policy model, enforcement details, and configuration are documented in the Resource Discovery building block: see [Data Catalogue — Access Control](https://eoepca.readthedocs.io/projects/resource-discovery/en/latest/design/data-catalogue/auth/). The policy implementation lives in the [`eoepca-plus` deployment repository](https://github.com/EOEPCA/eoepca-plus/tree/deploy-develop/argocd/eoepca/data-access/parts/stac-auth-proxy).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
       - api/endpoint-specification.md
       - api/health-checks.md
     - Administration:
+      - admin/auth.md
       - admin/autoscaling.md
 
 theme:


### PR DESCRIPTION
## What I'm changing

Companion to EOEPCA/resource-discovery#257 (refs EOEPCA/resource-discovery#203).

The Data Access BB shares its eoAPI deployment with the Resource Discovery BB, and that deployment's STAC API is now protected by [STAC Auth Proxy](https://github.com/developmentseed/stac-auth-proxy) with collection-prefix-based access policies (implemented in EOEPCA/eoepca-plus#118).

This adds a short **Access Control** page under *Administration* that summarizes the policy model and client expectations, and links to the full documentation in the Resource Discovery BB docs — keeping a single source of truth while making the auth behavior discoverable from this BB's docs.

## How you can test it

```bash
pip install -r docs/requirements.txt
mkdocs serve
```

`mkdocs build --strict` passes.


> [!NOTE]
> Merge order: this page links to the Resource Discovery Access Control docs added in EOEPCA/resource-discovery#257 — that PR should merge (and ReadTheDocs rebuild) first, or the link will 404.
